### PR TITLE
Some cpp cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Cargo.lock
 *.iml
 .idea
 
-
+libdummy/cmake-build-debug/
 libdummy/build/*
 !libdummy/build/.gitignore
+

--- a/libdummy/CMakeLists.txt
+++ b/libdummy/CMakeLists.txt
@@ -3,9 +3,9 @@ project (dummy)
 
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../target/debug/deps )
 
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
-add_library (dummy SHARED internal.cpp lib.cpp)
+add_library (dummy SHARED internal.cpp MyLibrary.cpp MyLibrary.h lib.cpp)
 target_include_directories (dummy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Actually not necessary, done by default with SHARED targets, but adding here for reference

--- a/libdummy/MyLibrary.cpp
+++ b/libdummy/MyLibrary.cpp
@@ -1,0 +1,106 @@
+#include <iostream>
+#include <chrono>
+
+#include "MyLibrary.h"
+
+MyLibrary::~MyLibrary() {
+    std::cout << "lib destroyed" << std::endl;
+}
+
+void MyLibrary::startIncrThread(InternalHandler * h, const std::string& dest) {
+    //Start thread
+    incrThreads.emplace_back( std::thread( &MyLibrary::incr, this, h, std::string(dest) ) );
+}
+
+void MyLibrary::shutdown() {
+    //Stop and join all threads
+    done = true;
+    for( auto& thread : incrThreads ) {
+        thread.join();
+    }
+}
+
+int MyLibrary::send(const std::string& dest, const char* arg, size_t argLen){
+    std::cout << "C side send " << dest << std::endl;
+
+    //Lock before accessing handlers map.
+    std::shared_lock guard(handlersGuard);
+
+    auto search = handlers.find(dest);
+    if(search != handlers.end()){
+        search->second->onSend(dest, arg, argLen);
+        startIncrThread(search->second, dest);
+        return 0;
+    } else {
+        std::cout << "handler for "<<dest << " was not found" << std::endl;
+        return -1;
+    }
+}
+
+
+int MyLibrary::handle(const std::string& dest, InternalHandler * internal_handler ){
+    std::cout << "C side handle " << dest << std::endl;
+
+    //NOTE this could be a shared mutex (this would be an exclusive case for 'emplace')
+    std::unique_lock guard(handlersGuard);
+
+    handlers.emplace(dest, internal_handler);
+    return 0;
+}
+
+int MyLibrary::cancel(const std::string& dest, InternalHandler * internal_handler ){
+    std::cout << "C side cancel " << dest << std::endl;
+
+    //Lock before accessing handlers map.
+    std::unique_lock guard(handlersGuard);
+
+    auto search = handlers.find(dest);
+    if(search != handlers.end()){
+        if(search->second == internal_handler){
+            delete search->second;
+            handlers.erase(dest);
+            return 0;
+        } else {
+            std::cout << "wrong internal_handler " << std::endl;
+        }
+    } else {
+        std::cout << "handler for "<<dest << " was not found, hard search" << std::endl;
+        for (auto const& e : handlers){
+            if(e.second == internal_handler){
+                std::cout << "hard search: found handler for "<< e.first << std::endl;
+                handlers.erase(e.first);
+                delete internal_handler;
+                return 0;
+            }
+        }
+    }
+
+    return -1;
+}
+
+void MyLibrary::incr(InternalHandler * h, const std::string& dest) {
+    int b = 0;
+    auto rec = std::string("recurrent from c side: ");
+    while( b < 20 ){
+        b++;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        if( done ){
+            std::cout<< "ON THE C SIDE lib was shutdown. this ptr is invalid"<< std::endl;
+            return;
+        }
+        auto i = std::to_string(b);
+        rec.append(i);
+        std::cout<< "ON THE C SIDE loop " << rec << " thread id: "<<std::this_thread::get_id()<< std::endl;
+
+        //Lock before accessing handlers map.
+        std::shared_lock guard(handlersGuard);
+
+        if(handlers.find(dest) != handlers.end()){
+            h->onSend(dest, rec.c_str(), rec.length());
+        } else {
+            std::cout<< "ON THE C SIDE loop '" << dest <<"' removed" << std::endl;
+            return;
+        }
+    }
+}
+

--- a/libdummy/MyLibrary.cpp
+++ b/libdummy/MyLibrary.cpp
@@ -4,20 +4,16 @@
 #include "MyLibrary.h"
 
 MyLibrary::~MyLibrary() {
+    done = true;
+    for( auto& thread : incrThreads ) {
+        thread.join();
+    }
     std::cout << "lib destroyed" << std::endl;
 }
 
 void MyLibrary::startIncrThread(InternalHandler * h, const std::string& dest) {
     //Start thread
     incrThreads.emplace_back( std::thread( &MyLibrary::incr, this, h, std::string(dest) ) );
-}
-
-void MyLibrary::shutdown() {
-    //Stop and join all threads
-    done = true;
-    for( auto& thread : incrThreads ) {
-        thread.join();
-    }
 }
 
 int MyLibrary::send(const std::string& dest, const char* arg, size_t argLen){

--- a/libdummy/MyLibrary.h
+++ b/libdummy/MyLibrary.h
@@ -1,0 +1,33 @@
+#ifndef DUMMY_MYLIBRARY_H
+#define DUMMY_MYLIBRARY_H
+
+#include <shared_mutex>
+#include <map>
+#include <deque>
+#include <atomic>
+#include <thread>
+
+#include "internal.h"
+
+class MyLibrary {
+
+public:
+    MyLibrary() = default;
+    virtual ~MyLibrary();
+
+    void startIncrThread(InternalHandler * h, const std::string& dest);
+    int send(const std::string& dest, const char* arg, size_t argLen);
+    int handle(const std::string& dest, InternalHandler * internal_handler);
+    int cancel(const std::string& dest, InternalHandler * internal_handler);
+    void shutdown();
+
+private:
+    std::map<std::string, InternalHandler*> handlers;
+    std::shared_mutex handlersGuard;
+    std::deque<std::thread> incrThreads;
+    std::atomic<bool> done = false;
+
+    void incr(InternalHandler* h, const std::string& dest);
+};
+
+#endif //DUMMY_MYLIBRARY_H

--- a/libdummy/internal.h
+++ b/libdummy/internal.h
@@ -1,6 +1,8 @@
-#include "lib.h"
-#include <iostream>
+#ifndef DUMMY_INTERNAL_H
+#define DUMMY_INTERNAL_H
 
+#include <iostream>
+#include "lib.h"
 
 ////////// ASYNC CB test
 class InternalHandler {
@@ -20,3 +22,4 @@ class InternalHandler {
     }
 };
 
+#endif // DUMMY_INTERNAL_H

--- a/libdummy/lib.cpp
+++ b/libdummy/lib.cpp
@@ -1,140 +1,14 @@
+//
+// Created by bentlesf on 2/13/21.
+//
 
-#include "lib.h"
-#include <iostream>
-#include <chrono>
-#include <map>
+#include <string>
+
+#include "MyLibrary.h"
 #include "internal.h"
-#include <vector>
-#include <shared_mutex>
-#include <mutex>
+#include "lib.h"
 
-std::mutex g_display_mutex;
-
-////////// ASYNC CB test
-class MyLibrary {
-   std::map<std::string, InternalHandler*> handlers;
-   std::shared_timed_mutex handlers_mutex;
-//   std::vector<std::thread> ths;
-   void incr(InternalHandler * h, const std::string dest);
- public:
-   ~MyLibrary();
-
-   void start(InternalHandler * h, const std::string& dest);
-   int send(const std::string& dest, const char* arg, size_t argLen);
-   int handle(const std::string& dest, InternalHandler * internal_handler);
-   int cancel(const std::string& dest, InternalHandler * internal_handler);
-};
-
-MyLibrary::~MyLibrary() {
-    std::cout<< "lib destroyed" <<std::endl;
-}
-
-void MyLibrary::start(InternalHandler * h, const std::string& dest) {
-    //Start thread
-    auto copy = std::string(dest);
-    //I think I'm doing this std::move right ?
-    auto t = std::thread(&MyLibrary::incr, this, h, std::move(copy));
-//  ths.push_back(std::move(t));
-    t.detach();
-}
-
-int MyLibrary::send(const std::string& dest, const char* arg, size_t argLen){
-    std::cout << "C side send " << dest << std::endl;
-
-    //Lock before accessing handlers map.
-    std::shared_lock<std::shared_timed_mutex> guard(handlers_mutex, std::defer_lock);
-
-    auto search = handlers.find(dest);
-    if(search != handlers.end()){
-        search->second->onSend(dest, arg, argLen);
-        start(search->second, dest);
-        return 0;
-    } else {
-        std::cout << "handler for "<<dest << " was not found" << std::endl;
-        return -1;
-    }
-}
-
-
-int MyLibrary::handle(const std::string& dest, InternalHandler * internal_handler ){
-    std::cout << "C side handle " << dest << std::endl;
-
-    //NOTE this could be a shared mutex (this would be an exclusive case for 'emplace')
-    std::unique_lock<std::shared_timed_mutex> guard(handlers_mutex, std::defer_lock);
-
-    handlers.emplace(dest, internal_handler);
-    return 0;
-}
-
-int MyLibrary::cancel(const std::string& dest, InternalHandler * internal_handler ){
-    std::cout << "C side cancel " << dest << std::endl;
-
-    //Lock before accessing handlers map.
-    std::unique_lock<std::shared_timed_mutex> guard(handlers_mutex, std::defer_lock);
-
-    auto search = handlers.find(dest);
-    if(search != handlers.end()){
-        if(search->second == internal_handler){
-            delete search->second;
-            handlers.erase(dest);
-            return 0;
-        } else {
-            std::cout << "wrong internal_handler " << std::endl;
-        }
-    } else {
-        std::cout << "handler for "<<dest << " was not found, hard search" << std::endl;
-        for (auto const& e : handlers){
-            if(e.second == internal_handler){
-                std::cout << "hard search: found handler for "<< e.first << std::endl;
-                handlers.erase(e.first);
-                delete internal_handler;
-                return 0;
-            }
-        }
-    }
-
-    return -1;
-}
-
-
-std::shared_timed_mutex lib_mutex;
 auto lib = new MyLibrary();
-
-void MyLibrary::incr(InternalHandler * h, const std::string dest) {
-    int b = 0;
-    auto rec = std::string("recurrent from c side: ");
-    while( b < 20){
-        b++;
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-        lib_mutex.lock_shared();
-        if(lib == nullptr){
-            lib_mutex.unlock_shared();
-            std::cout<< "ON THE C SIDE lib was shutdown. this ptr is invalid"<< std::endl;
-            return;
-        }
-        auto i = std::to_string(b);
-        rec.append(i);
-        std::thread::id this_id = std::this_thread::get_id();
-        g_display_mutex.lock();
-        std::cout<< "ON THE C SIDE loop " << rec << " thread id: "<<this_id<< std::endl;
-        g_display_mutex.unlock();
-
-        //Lock before accessing handlers map.
-        std::shared_lock<std::shared_timed_mutex> guard(handlers_mutex, std::defer_lock);
-
-        if(this->handlers.find(dest) != this->handlers.end()){
-            h->onSend(dest, rec.c_str(), rec.length());
-            lib_mutex.unlock_shared();
-        } else {
-            std::cout<< "ON THE C SIDE loop '" << dest <<"' removed" << std::endl;
-            lib_mutex.unlock_shared();
-            return;
-        }
-    }
-}
-
-
-/////////// Externs
 
 int send(const char* dest, const char* arg, size_t argLen){
     auto s = std::string(dest);
@@ -157,23 +31,7 @@ int cancel(const char * dest, void *ctx) {
 
 void shutdown(){
     std::cout << "Shutdown libdummy" << std::endl;
-    lib_mutex.lock();
+    lib->shutdown();
     delete lib;
     lib = nullptr;
-    lib_mutex.unlock();
 }
-
-///////////////
-
-
-/*
-
-   //build .so (MAC)
-   g++ -shared -std=c++14 -o libdummy.so lib.cpp -lc
-
-   //build .so (linux)
-   g++ -shared -std=c++14 -o libdummy.so lib.cpp -lc -fPIC
-
-   https://nachtimwald.com/2017/08/18/wrapping-c-objects-in-c/
-
-*/

--- a/libdummy/lib.cpp
+++ b/libdummy/lib.cpp
@@ -31,7 +31,6 @@ int cancel(const char * dest, void *ctx) {
 
 void shutdown(){
     std::cout << "Shutdown libdummy" << std::endl;
-    lib->shutdown();
     delete lib;
     lib = nullptr;
 }

--- a/libdummy/lib.h
+++ b/libdummy/lib.h
@@ -1,7 +1,6 @@
-#pragma once
+#ifndef DUMMY_LIB_H
+#define DUMMY_LIB_H
 
-#include <thread>
-#include <string>
 
 typedef void* FFIHandler;
 
@@ -52,3 +51,8 @@ extern "C"
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+
+
+
+#endif // DUMMY_LIB_H

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     {
         let _h2 = setup_other_handler();
         cffi_explore::send("here", "another one".as_bytes());
-        cffi_explore::send("here12", "for other handl".as_bytes());
+        cffi_explore::send("here12", "for other handle".as_bytes());
         println!("We got it {:?}", &d);
         let mut count = 0;
         while count < 2 {


### PR DESCRIPTION
closes #3 

Sorry, refactored how the source is contained in different cpp/h files, so it looks like lots of change.  But the bulk is just code that's lifted & shifted from one file to another.  You'll probably recognize it.

build & valgrind output:
```
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ pushd libdummy/build
~/cffi-explore/libdummy/build ~/cffi-explore ~/cffi-explore ~/cffi-explore
bentlesf@mercury:~/cffi-explore/libdummy/build$ cmake ..
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/bentlesf/cffi-explore/libdummy/build
bentlesf@mercury:~/cffi-explore/libdummy/build$ cmake --build . -j 4
Scanning dependencies of target dummy
[ 50%] Building CXX object CMakeFiles/dummy.dir/internal.cpp.o
[ 50%] Building CXX object CMakeFiles/dummy.dir/MyLibrary.cpp.o
[ 75%] Building CXX object CMakeFiles/dummy.dir/lib.cpp.o
[100%] Linking CXX shared library /home/bentlesf/cffi-explore/target/debug/deps/libdummy.so
[100%] Built target dummy
bentlesf@mercury:~/cffi-explore/libdummy/build$ popd
~/cffi-explore ~/cffi-explore ~/cffi-explore
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ cargo build
   Compiling cffi-explore v0.1.0 (/home/bentlesf/cffi-explore)
    Finished dev [unoptimized + debuginfo] target(s) in 1.35s
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ export LD_LIBRARY_PATH=/home/bentlesf/cffi-explore/target/debug/deps/
bentlesf@mercury:~/cffi-explore$ valgrind --leak-check=full target/debug/cffi-explore
==331460== Memcheck, a memory error detector
==331460== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==331460== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==331460== Command: target/debug/cffi-explore
==331460== 
C side handle here
C side send here
C side onSend here
User space 'here' tid: ThreadId(1) 
We got it RwLock { data: Some("ledata to send") }
ON THE C SIDE loop recurrent from c side: 1 thread id: 94344960
C side onSend here
User space 'here' tid: ThreadId(2) 
C side handle here12
C side send here
C side onSend here
User space 'here' tid: ThreadId(1) 
C side send here12
C side onSend here12
User space 'here12' tid: ThreadId(1) 
ON THE C SIDE loop recurrent from c side: 12 thread id: 94344960
C side onSend here
We got it RwLock { data: Some("another one") }
User space 'here' tid: ThreadId(2) 
ON THE C SIDE loop recurrent from c side: 1 thread id: 102737664
C side onSend here
User space 'here' tid: ThreadId(3) 
ON THE C SIDE loop recurrent from c side: 1 thread id: 111130368
C side onSend here12
User space 'here12' tid: ThreadId(4) 
ON THE C SIDE loop recurrent from c side: 123 thread id: 94344960
C side onSend here
User space 'here' tid: ThreadId(2) 
ON THE C SIDE loop recurrent from c side: 12 thread id: 102737664
C side onSend here
User space 'here' tid: ThreadId(3) 
We got it RwLock { data: Some("recurrent from c side: 12") }
ON THE C SIDE loop recurrent from c side: 12 thread id: 111130368
C side onSend here12
User space 'here12' tid: ThreadId(4) 
ON THE C SIDE loop recurrent from c side: 1234 thread id: 94344960
C side onSend here
User space 'here' tid: ThreadId(2) 
ON THE C SIDE loop recurrent from c side: 123 thread id: 102737664
C side onSend here
User space 'here' tid: ThreadId(3) 
ON THE C SIDE loop recurrent from c side: 123 thread id: 111130368
C side onSend here12
User space 'here12' tid: ThreadId(4) 
ON THE C SIDE loop recurrent from c side: 12345 thread id: 94344960
C side onSend here
User space 'here' tid: ThreadId(2) 
ON THE C SIDE loop recurrent from c side: 1234 thread id: 102737664
C side onSend here
User space 'here' tid: ThreadId(3) 
We got it RwLock { data: Some("recurrent from c side: 1234") }
C side cancel here
~InternalHandler() destroyed
dropped UserSpaceWrapper, ctx freed:'false'
C side cancel 
handler for  was not found, hard search
hard search: found handler for here12
~InternalHandler() destroyed
dropped UserSpaceWrapper, ctx freed:'true'
ON THE C SIDE loop recurrent from c side: 123456 thread id: 94344960
ON THE C SIDE loop 'here' removed
ON THE C SIDE loop recurrent from c side: 1234 thread id: 111130368
ON THE C SIDE loop 'here12' removed
ON THE C SIDE loop recurrent from c side: 12345 thread id: 102737664
ON THE C SIDE loop 'here' removed
Shutdown libdummy
lib destroyed
==331460== 
==331460== HEAP SUMMARY:
==331460==     in use at exit: 0 bytes in 0 blocks
==331460==   total heap usage: 87 allocs, 87 frees, 80,795 bytes allocated
==331460== 
==331460== All heap blocks were freed -- no leaks are possible
==331460== 
==331460== For lists of detected and suppressed errors, rerun with: -s
==331460== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
bentlesf@mercury:~/cffi-explore$ 
```
